### PR TITLE
Add options dry-run and header-stamp

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -35,3 +35,13 @@ Available options:
 --exclude=EXCLUDE        Comma-separated list of folders and files to exclude from the update [default: ""]
 --extensions=EXTENSIONS  Comma-separated list of file extensions to update [default: "php,js,css,tpl,html.twig,json,vue"]
 ```
+
+## Development
+
+Install dependencies with composer. Two CI tools are configured for this project: php-cs-fixer and phpstan
+
+```
+composer install
+php vendor/bin/php-cs-fixer fix --no-interaction --dry-run --diff
+php phpstan analyse tests/phpstan/phpstan.neon
+```

--- a/bin/header-stamp
+++ b/bin/header-stamp
@@ -1,7 +1,7 @@
 #!/usr/bin/env php
 <?php
 /**
- * 2007-2019 PrestaShop and Contributors
+ * 2007-2020 PrestaShop and Contributors
  *
  * NOTICE OF LICENSE
  *
@@ -20,7 +20,7 @@
  * needs please refer to https://www.prestashop.com for more information.
  *
  * @author    PrestaShop SA <contact@prestashop.com>
- * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @copyright 2007-2020 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */

--- a/src/Command/UpdateLicensesCommand.php
+++ b/src/Command/UpdateLicensesCommand.php
@@ -4,10 +4,10 @@
  *
  * NOTICE OF LICENSE
  *
- * This source file is subject to the Open Software License (OSL 3.0)
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/OSL-3.0
+ * https://opensource.org/licenses/AFL-3.0
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
@@ -20,7 +20,7 @@
  *
  * @author    PrestaShop SA <contact@prestashop.com>
  * @copyright 2007-2020 PrestaShop SA and Contributors
- * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
 
@@ -138,7 +138,7 @@ class UpdateLicensesCommand extends Command
                 'dry-run',
                 null,
                 InputOption::VALUE_NONE,
-                false
+                'Dry-run mode does not modify files'
             );
     }
 
@@ -165,16 +165,16 @@ class UpdateLicensesCommand extends Command
             $this->findAndCheckExtension($input, $output, $extension);
         }
 
-        if ($this->displayReport) {
-            $this->printPrettyReport($input, $output);
-        }
-
         if ($this->runAsDry) {
+            $this->printDryRunPrettyReport($input, $output);
+
             if (empty($this->reporter->getReport()['fixed'])) {
                 return 0;
             } else {
                 return 1;
             }
+        } elseif ($this->displayReport) {
+            $this->printPrettyReport($input, $output);
         }
     }
 
@@ -388,5 +388,19 @@ class UpdateLicensesCommand extends Command
             $style->text(ucfirst($section) . ':');
             $style->listing($report[$section]);
         }
+    }
+
+    private function printDryRunPrettyReport(InputInterface $input, OutputInterface $output)
+    {
+        $style = new SymfonyStyle($input, $output);
+        $style->section('Header Stamp Dry Run Report');
+
+        $report = $this->reporter->getReport();
+
+        if (empty($report['fixed'])) {
+            return;
+        }
+        $style->text('Files with bad license headers:');
+        $style->listing($report['fixed']);
     }
 }

--- a/src/Command/UpdateLicensesCommand.php
+++ b/src/Command/UpdateLicensesCommand.php
@@ -33,7 +33,6 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Output\Output;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Finder\Finder;
@@ -347,7 +346,7 @@ class UpdateLicensesCommand extends Command
             return false;
         }
 
-        $content = (array)json_decode($file->getContents());
+        $content = (array) json_decode($file->getContents());
         $oldContent = $content;
         $content['author'] = 'PrestaShop';
         $content['license'] = (false !== strpos($this->license, 'afl')) ? 'AFL-3.0' : 'OSL-3.0';
@@ -363,7 +362,7 @@ class UpdateLicensesCommand extends Command
 
         $this->reportOperationResult($content, $oldContent, $file->getFilename());
 
-        return (false !== $result);
+        return false !== $result;
     }
 
     private function reportOperationResult($newFileContent, $oldFileContent, $filename)

--- a/src/Command/UpdateLicensesCommand.php
+++ b/src/Command/UpdateLicensesCommand.php
@@ -171,9 +171,9 @@ class UpdateLicensesCommand extends Command
 
         if ($this->runAsDry) {
             if (empty($this->reporter->getReport()['fixed'])) {
-                return 1;
-            } else {
                 return 0;
+            } else {
+                return 1;
             }
         }
     }

--- a/src/LicenseHeader.php
+++ b/src/LicenseHeader.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2019 PrestaShop and Contributors
+ * 2007-2020 PrestaShop and Contributors
  *
  * NOTICE OF LICENSE
  *
@@ -19,7 +19,7 @@
  * needs please refer to https://www.prestashop.com for more information.
  *
  * @author    PrestaShop SA <contact@prestashop.com>
- * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @copyright 2007-2020 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */

--- a/src/Reporter.php
+++ b/src/Reporter.php
@@ -4,10 +4,10 @@
  *
  * NOTICE OF LICENSE
  *
- * This source file is subject to the Open Software License (OSL 3.0)
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/OSL-3.0
+ * https://opensource.org/licenses/AFL-3.0
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
@@ -20,7 +20,7 @@
  *
  * @author    PrestaShop SA <contact@prestashop.com>
  * @copyright 2007-2020 PrestaShop SA and Contributors
- * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
 

--- a/src/Reporter.php
+++ b/src/Reporter.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * 2007-2020 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\HeaderStamp;
+
+/**
+ * Reporter in charge of reporting what HeaderStamp has done
+ */
+class Reporter
+{
+    private $report = [
+        'fixed' => [],
+        'ignored' => [],
+        'failed' => [],
+    ];
+
+    public function reportLicenseHasBeenFixed($fixedFilename)
+    {
+        $this->report['fixed'][] = $fixedFilename;
+    }
+
+    public function reportLicenseWasFine($fixedFilename)
+    {
+        $this->report['nothing to fix'][] = $fixedFilename;
+    }
+
+    public function reportLicenseCouldNotBeFixed($fixedFilename)
+    {
+        $this->report['failed'][] = $fixedFilename;
+    }
+
+    /**
+     * @return array[]
+     */
+    public function getReport()
+    {
+        return $this->report;
+    }
+}


### PR DESCRIPTION
I have added a `Reporter` class in charge of monitoring the actions being done and 2 feature flags: `display-report` and `dry-run`

The display-report option will output something like this:
```
Header Stamp Report
-------------------

 Fixed:
 * module.js
 * webpack.config.js
 * module.js
 * module.css
 * navbar.tpl
 * end.tpl
 * welcome.tpl
 * content.tpl
 * tooltip.tpl
 * lost.tpl
 * popup.tpl
 * package.json
 * composer.json

 Nothing to fix:
 * AdminWelcomeController.php
 * Configuration.php
 * OnBoarding.php
 * welcome.php
 * OnBoarding.js
```