### PR TITLE
Add fake module sample to test JS, CSS and Twig files

### DIFF
--- a/tests/integration/expected/fakemodule/fakemodule.php
+++ b/tests/integration/expected/fakemodule/fakemodule.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+class Fakemodule extends Module
+{
+}

--- a/tests/integration/expected/fakemodule/translations/cs.php
+++ b/tests/integration/expected/fakemodule/translations/cs.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+
+
+global $_MODULE;
+$_MODULE = array();
+
+$_MODULE['<{gamification}prestashop>gamification_3d4aafb2eedeba2fbf92e852f0af745a'] = 'Obchodní znalosti';
+$_MODULE['<{gamification}prestashop>gamification_bacc1bf300527bad9c6ac2d3b875a8d8'] = 'Staňte se e-commerce expertem mrknutím oka!';
+$_MODULE['<{gamification}prestashop>admingamificationcontroller_ca96b4f8d13722aac99da25f94ea1711'] = 'Vaše obchodní znalosti';
+$_MODULE['<{gamification}prestashop>admingamificationcontroller_98f770b0af18ca763421bac22b4b6805'] = 'Funkce';
+$_MODULE['<{gamification}prestashop>admingamificationcontroller_f5c7922da355fd289ec1d6469e0583a7'] = 'Dosažené výsledky';
+$_MODULE['<{gamification}prestashop>admingamificationcontroller_8189ecf686157db0c0274c1f49373318'] = 'Mezinárodní';
+$_MODULE['<{gamification}prestashop>admingamificationcontroller_851f12a0c936baace7f0e734d5c624e7'] = '1. Začátečník';
+$_MODULE['<{gamification}prestashop>admingamificationcontroller_583981a16ea761fe852b64094d8a887e'] = '2. Profesionál';
+$_MODULE['<{gamification}prestashop>admingamificationcontroller_38f7af7416ffcd1524d8a4acda756cbf'] = '3.  Expert';
+$_MODULE['<{gamification}prestashop>admingamificationcontroller_e7613fe56cdbeddfc9bb6276fd0f0d12'] = '4. Kouzelník';
+$_MODULE['<{gamification}prestashop>admingamificationcontroller_8d03eaad7ff7babdd33c2c74fe479ed0'] = '5.  Guru';
+$_MODULE['<{gamification}prestashop>admingamificationcontroller_e4be4f3e3ae4ee9dda6b60815bf774c1'] = '6. Legenda';
+$_MODULE['<{gamification}prestashop>filters_b1c94ca2fbc3e78fc30069c8d0f01680'] = 'Všechny';
+$_MODULE['<{gamification}prestashop>filters_5364259abab90e94890f2ed2481b9824'] = 'Ověřeno';
+$_MODULE['<{gamification}prestashop>filters_dc450ba947e6adecbdbe68c25de03a1b'] = 'Neověřeno';
+$_MODULE['<{gamification}prestashop>filters_07ad815187b53dc2ceaf5ad6e0a12bb1'] = 'Úroveň:';
+$_MODULE['<{gamification}prestashop>view_a0db49ba470c1c9ae2128c3470339153'] = 'Úroveň';
+$_MODULE['<{gamification}prestashop>view_2a0ab6a9172272d54f0d601b0ac157f3'] = 'Staňte e-commerce expertem mílovými kroky!';
+$_MODULE['<{gamification}prestashop>view_cb3d475bd997e38c100704631dbab020'] = 'Se všemi skvělými funkcemi a výhodami, které nabízí PrestaShop, je důležité udržet krok!';
+$_MODULE['<{gamification}prestashop>view_2c3193c85bb2555c333adfcfb824804a'] = 'Hlavním cílem všech funkcí, které nabízíme, je, aby se vám dařilo v e-commerce světě. Za účelem dosažení tohoto cíle, jsme vytvořili systém známek a bodů, které vám usnadní sledovat své pokroky obchodníka. Systém je členěn do tří úrovní, z nichž všechny jsou nedílnou součástí úspěchu ve světě e-commerce: (I) Používání klíčových e-commerce funkcí ve vašem obchodě; (II) Výkonnost vašeho obchodu; (III) Přítomnost obchodu na mezinárodních trzích.';
+$_MODULE['<{gamification}prestashop>view_6b766dc388ad21053bde0f8fd95d1e04'] = 'Čím většího pokroku dosáhne váš obchod, tím více známek a bodů získáte. Není třeba zasílat jakékoli informace nebo vyplňovat formuláře, víme, jak jste zaneprázdněni, vše je automatické!';
+$_MODULE['<{gamification}prestashop>view_21dc1cfc9ef1cdfbb665cab323d5e1a9'] = 'Nyní, kliknutím na tlačítko, budete mít možnost vidět vlastnosti zlepšujícího se prodeje, které mohou zatím chybět. Využijte tyto výhody a podívejte se na to níže!';
+$_MODULE['<{gamification}prestashop>view_8ba134cf899d862079bbf3964bc7d7d4'] = 'Náš tým je k dispozici, aby vám pomohl k pokroku... Kontaktujte nás nyní!';
+$_MODULE['<{gamification}prestashop>view_bcc254b55c4a1babdf1dcb82c207506b'] = 'Telefon';
+$_MODULE['<{gamification}prestashop>view_b39131f9b4f81406be4f9cca784f99c8'] = 'Telefonicky: +1 (888) 947.6543';
+$_MODULE['<{gamification}prestashop>view_ce8ae9da5b7cd6c3df2929543a9af92d'] = 'E-mail';
+$_MODULE['<{gamification}prestashop>view_119c7e70192829bf606e3774254c6167'] = 'E-mailem';
+$_MODULE['<{gamification}prestashop>view_6b6ac7834d96afefbca5677814769109'] = 'Dosažená úroveň';
+$_MODULE['<{gamification}prestashop>view_82338dd23ce2fd2f6d3606c20f4ee96e'] = 'Žádná známka v této sekci';
+$_MODULE['<{gamification}prestashop>notification_a0db49ba470c1c9ae2128c3470339153'] = 'Úroveň';
+$_MODULE['<{gamification}prestashop>notification_ca96b4f8d13722aac99da25f94ea1711'] = 'Vaše obchodní znalosti';
+$_MODULE['<{gamification}prestashop>notification_16a1daea9e8873542aec1e820798aa44'] = 'Poslední známka:';
+$_MODULE['<{gamification}prestashop>notification_15377177c0259c6f79341cc57da13f19'] = 'Další známka:';
+$_MODULE['<{gamification}prestashop>notification_f8978f781f97e6f851e9c8f7059c37b2'] = 'Zobrazit můj celý profil';
+$_MODULE['<{gamification}prestashop>filters_e659b52eba1f0299b2d8ca3483919e72'] = 'Typ:';
+$_MODULE['<{gamification}prestashop>filters_18325105de95083e4a1d10b78f29c2bc'] = 'Stav:';

--- a/tests/integration/expected/fakemodule/views/css/random.css
+++ b/tests/integration/expected/fakemodule/views/css/random.css
@@ -1,0 +1,21 @@
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+.icon-aaa:before {
+    content: "\f140";
+}

--- a/tests/integration/expected/fakemodule/views/js/random.js
+++ b/tests/integration/expected/fakemodule/views/js/random.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+$(document).ready( function () {
+	console.log('prestashop');
+});

--- a/tests/integration/expected/fakemodule/views/templates/a.html.twig
+++ b/tests/integration/expected/fakemodule/views/templates/a.html.twig
@@ -1,0 +1,97 @@
+{#**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ *#}
+
+{%- block choice_widget_expanded -%}
+    <div {{ block('widget_container_attributes') }}>
+        {% for name, choices in form.vars.choices %}
+            {% if choices is iterable  %}
+
+                <label class="choice_category">
+                    <strong>
+                        {{ choice_translation_domain is same as(false) ? name : name|trans({}, choice_translation_domain) }}
+                    </strong>
+                </label>
+                <div>
+                    {% for key,choice in choices %}
+                        {{ form_widget(form[key]) }}
+                        {{ form_label(form[key]) }}
+                    {% endfor %}
+                </div>
+
+            {% else %}
+
+                {{- form_widget(form[name]) -}}
+                {{- form_label(form[name], null, {translation_domain: choice_translation_domain}) -}}
+
+            {% endif %}
+        {% endfor %}
+    </div>
+{%- endblock choice_widget_expanded -%}
+
+{% block checkbox_widget -%}
+    {% set parent_label_class = parent_label_class|default('') -%}
+    {% set switch = switch|default('') -%}
+    {% set checkbox_input %}
+        <input type="checkbox" class="js-bulk-action-checkbox"
+               {% if switch %}data-toggle="switch"{% endif %} {% if switch %}class="{{ switch }}"{% endif %} {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %} />
+        <i class="md-checkbox-control"></i>
+    {% endset %}
+
+    {% if 'checkbox-inline' in parent_label_class %}
+        <div class="md-checkbox md-checkbox-inline">
+            {{- form_label(form, null, { widget: checkbox_input }) -}}
+        </div>
+    {% else -%}
+        <div class="md-checkbox my-1">
+            {{- form_label(form, null, { widget: checkbox_input }) -}}
+        </div>
+    {%- endif %}
+{%- endblock checkbox_widget %}
+
+{% block form_row -%}
+    {% spaceless %}
+        <div class="{{ block('form_row_class') }} {% if (not compound or force_error|default(false)) and not valid %} has-error{% endif %}">
+            {% if form.vars.label is not same as(false) %}
+                {{ form_label(form) }}
+                {% set formGroupClasses = block('form_group_class') %}
+            {% else %}
+                {% set formGroupClasses = block('unlabeled_form_group_class') %}
+            {% endif %}
+            <div class="{{ formGroupClasses }}">
+                {{ form_widget(form) }}
+                {{ form_errors(form) }}
+            </div>
+        </div>
+    {% endspaceless %}
+{%- endblock form_row %}
+
+{% block form_row_class -%}
+    form-group row
+{%- endblock form_row_class %}
+
+{% block unlabeled_form_group_class -%}
+    col-sm-12
+{%- endblock unlabeled_form_group_class %}
+
+{%- block custom_url_widget -%}
+    <div class="form-control {{ attr.class }}">
+        {{ form_row(form.title) }}
+        {{ form_row(form.url) }}
+    </div>
+{%- endblock custom_url_widget -%}

--- a/tests/integration/module-samples/fakemodule/fakemodule.php
+++ b/tests/integration/module-samples/fakemodule/fakemodule.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Copyright since 2006 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright Since 2006 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+class Fakemodule extends Module
+{
+}

--- a/tests/integration/module-samples/fakemodule/translations/cs.php
+++ b/tests/integration/module-samples/fakemodule/translations/cs.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Copyright 2003-2020 PrestaShop SA
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright 2003-2020 PrestaShop SA
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+
+
+global $_MODULE;
+$_MODULE = array();
+
+$_MODULE['<{gamification}prestashop>gamification_3d4aafb2eedeba2fbf92e852f0af745a'] = 'Obchodní znalosti';
+$_MODULE['<{gamification}prestashop>gamification_bacc1bf300527bad9c6ac2d3b875a8d8'] = 'Staňte se e-commerce expertem mrknutím oka!';
+$_MODULE['<{gamification}prestashop>admingamificationcontroller_ca96b4f8d13722aac99da25f94ea1711'] = 'Vaše obchodní znalosti';
+$_MODULE['<{gamification}prestashop>admingamificationcontroller_98f770b0af18ca763421bac22b4b6805'] = 'Funkce';
+$_MODULE['<{gamification}prestashop>admingamificationcontroller_f5c7922da355fd289ec1d6469e0583a7'] = 'Dosažené výsledky';
+$_MODULE['<{gamification}prestashop>admingamificationcontroller_8189ecf686157db0c0274c1f49373318'] = 'Mezinárodní';
+$_MODULE['<{gamification}prestashop>admingamificationcontroller_851f12a0c936baace7f0e734d5c624e7'] = '1. Začátečník';
+$_MODULE['<{gamification}prestashop>admingamificationcontroller_583981a16ea761fe852b64094d8a887e'] = '2. Profesionál';
+$_MODULE['<{gamification}prestashop>admingamificationcontroller_38f7af7416ffcd1524d8a4acda756cbf'] = '3.  Expert';
+$_MODULE['<{gamification}prestashop>admingamificationcontroller_e7613fe56cdbeddfc9bb6276fd0f0d12'] = '4. Kouzelník';
+$_MODULE['<{gamification}prestashop>admingamificationcontroller_8d03eaad7ff7babdd33c2c74fe479ed0'] = '5.  Guru';
+$_MODULE['<{gamification}prestashop>admingamificationcontroller_e4be4f3e3ae4ee9dda6b60815bf774c1'] = '6. Legenda';
+$_MODULE['<{gamification}prestashop>filters_b1c94ca2fbc3e78fc30069c8d0f01680'] = 'Všechny';
+$_MODULE['<{gamification}prestashop>filters_5364259abab90e94890f2ed2481b9824'] = 'Ověřeno';
+$_MODULE['<{gamification}prestashop>filters_dc450ba947e6adecbdbe68c25de03a1b'] = 'Neověřeno';
+$_MODULE['<{gamification}prestashop>filters_07ad815187b53dc2ceaf5ad6e0a12bb1'] = 'Úroveň:';
+$_MODULE['<{gamification}prestashop>view_a0db49ba470c1c9ae2128c3470339153'] = 'Úroveň';
+$_MODULE['<{gamification}prestashop>view_2a0ab6a9172272d54f0d601b0ac157f3'] = 'Staňte e-commerce expertem mílovými kroky!';
+$_MODULE['<{gamification}prestashop>view_cb3d475bd997e38c100704631dbab020'] = 'Se všemi skvělými funkcemi a výhodami, které nabízí PrestaShop, je důležité udržet krok!';
+$_MODULE['<{gamification}prestashop>view_2c3193c85bb2555c333adfcfb824804a'] = 'Hlavním cílem všech funkcí, které nabízíme, je, aby se vám dařilo v e-commerce světě. Za účelem dosažení tohoto cíle, jsme vytvořili systém známek a bodů, které vám usnadní sledovat své pokroky obchodníka. Systém je členěn do tří úrovní, z nichž všechny jsou nedílnou součástí úspěchu ve světě e-commerce: (I) Používání klíčových e-commerce funkcí ve vašem obchodě; (II) Výkonnost vašeho obchodu; (III) Přítomnost obchodu na mezinárodních trzích.';
+$_MODULE['<{gamification}prestashop>view_6b766dc388ad21053bde0f8fd95d1e04'] = 'Čím většího pokroku dosáhne váš obchod, tím více známek a bodů získáte. Není třeba zasílat jakékoli informace nebo vyplňovat formuláře, víme, jak jste zaneprázdněni, vše je automatické!';
+$_MODULE['<{gamification}prestashop>view_21dc1cfc9ef1cdfbb665cab323d5e1a9'] = 'Nyní, kliknutím na tlačítko, budete mít možnost vidět vlastnosti zlepšujícího se prodeje, které mohou zatím chybět. Využijte tyto výhody a podívejte se na to níže!';
+$_MODULE['<{gamification}prestashop>view_8ba134cf899d862079bbf3964bc7d7d4'] = 'Náš tým je k dispozici, aby vám pomohl k pokroku... Kontaktujte nás nyní!';
+$_MODULE['<{gamification}prestashop>view_bcc254b55c4a1babdf1dcb82c207506b'] = 'Telefon';
+$_MODULE['<{gamification}prestashop>view_b39131f9b4f81406be4f9cca784f99c8'] = 'Telefonicky: +1 (888) 947.6543';
+$_MODULE['<{gamification}prestashop>view_ce8ae9da5b7cd6c3df2929543a9af92d'] = 'E-mail';
+$_MODULE['<{gamification}prestashop>view_119c7e70192829bf606e3774254c6167'] = 'E-mailem';
+$_MODULE['<{gamification}prestashop>view_6b6ac7834d96afefbca5677814769109'] = 'Dosažená úroveň';
+$_MODULE['<{gamification}prestashop>view_82338dd23ce2fd2f6d3606c20f4ee96e'] = 'Žádná známka v této sekci';
+$_MODULE['<{gamification}prestashop>notification_a0db49ba470c1c9ae2128c3470339153'] = 'Úroveň';
+$_MODULE['<{gamification}prestashop>notification_ca96b4f8d13722aac99da25f94ea1711'] = 'Vaše obchodní znalosti';
+$_MODULE['<{gamification}prestashop>notification_16a1daea9e8873542aec1e820798aa44'] = 'Poslední známka:';
+$_MODULE['<{gamification}prestashop>notification_15377177c0259c6f79341cc57da13f19'] = 'Další známka:';
+$_MODULE['<{gamification}prestashop>notification_f8978f781f97e6f851e9c8f7059c37b2'] = 'Zobrazit můj celý profil';
+$_MODULE['<{gamification}prestashop>filters_e659b52eba1f0299b2d8ca3483919e72'] = 'Typ:';
+$_MODULE['<{gamification}prestashop>filters_18325105de95083e4a1d10b78f29c2bc'] = 'Stav:';

--- a/tests/integration/module-samples/fakemodule/views/css/random.css
+++ b/tests/integration/module-samples/fakemodule/views/css/random.css
@@ -1,0 +1,18 @@
+/**
+ * Copyright since 2018 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2018 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+.icon-aaa:before {
+    content: "\f140";
+}

--- a/tests/integration/module-samples/fakemodule/views/js/random.js
+++ b/tests/integration/module-samples/fakemodule/views/js/random.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright since 2018 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2018 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+$(document).ready( function () {
+	console.log('prestashop');
+});

--- a/tests/integration/module-samples/fakemodule/views/templates/a.html.twig
+++ b/tests/integration/module-samples/fakemodule/views/templates/a.html.twig
@@ -1,0 +1,103 @@
+{#**
+ * Copyright since 2006 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2006 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ *#}
+
+{%- block choice_widget_expanded -%}
+    <div {{ block('widget_container_attributes') }}>
+        {% for name, choices in form.vars.choices %}
+            {% if choices is iterable  %}
+
+                <label class="choice_category">
+                    <strong>
+                        {{ choice_translation_domain is same as(false) ? name : name|trans({}, choice_translation_domain) }}
+                    </strong>
+                </label>
+                <div>
+                    {% for key,choice in choices %}
+                        {{ form_widget(form[key]) }}
+                        {{ form_label(form[key]) }}
+                    {% endfor %}
+                </div>
+
+            {% else %}
+
+                {{- form_widget(form[name]) -}}
+                {{- form_label(form[name], null, {translation_domain: choice_translation_domain}) -}}
+
+            {% endif %}
+        {% endfor %}
+    </div>
+{%- endblock choice_widget_expanded -%}
+
+{% block checkbox_widget -%}
+    {% set parent_label_class = parent_label_class|default('') -%}
+    {% set switch = switch|default('') -%}
+    {% set checkbox_input %}
+        <input type="checkbox" class="js-bulk-action-checkbox"
+               {% if switch %}data-toggle="switch"{% endif %} {% if switch %}class="{{ switch }}"{% endif %} {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %} />
+        <i class="md-checkbox-control"></i>
+    {% endset %}
+
+    {% if 'checkbox-inline' in parent_label_class %}
+        <div class="md-checkbox md-checkbox-inline">
+            {{- form_label(form, null, { widget: checkbox_input }) -}}
+        </div>
+    {% else -%}
+        <div class="md-checkbox my-1">
+            {{- form_label(form, null, { widget: checkbox_input }) -}}
+        </div>
+    {%- endif %}
+{%- endblock checkbox_widget %}
+
+{% block form_row -%}
+    {% spaceless %}
+        <div class="{{ block('form_row_class') }} {% if (not compound or force_error|default(false)) and not valid %} has-error{% endif %}">
+            {% if form.vars.label is not same as(false) %}
+                {{ form_label(form) }}
+                {% set formGroupClasses = block('form_group_class') %}
+            {% else %}
+                {% set formGroupClasses = block('unlabeled_form_group_class') %}
+            {% endif %}
+            <div class="{{ formGroupClasses }}">
+                {{ form_widget(form) }}
+                {{ form_errors(form) }}
+            </div>
+        </div>
+    {% endspaceless %}
+{%- endblock form_row %}
+
+{% block form_row_class -%}
+    form-group row
+{%- endblock form_row_class %}
+
+{% block unlabeled_form_group_class -%}
+    col-sm-12
+{%- endblock unlabeled_form_group_class %}
+
+{%- block custom_url_widget -%}
+    <div class="form-control {{ attr.class }}">
+        {{ form_row(form.title) }}
+        {{ form_row(form.url) }}
+    </div>
+{%- endblock custom_url_widget -%}

--- a/tests/integration/runner/run.php
+++ b/tests/integration/runner/run.php
@@ -13,6 +13,7 @@ use Symfony\Component\Filesystem\Filesystem;
 $modulesToTest = [
     'gsitemap',
     'dashproducts',
+    'fakemodule',
 ];
 $workspaceID = 100;
 $filesystem = new Filesystem();


### PR DESCRIPTION
As said in https://github.com/PrestaShopCorp/header-stamp/pull/23, I wanted to cover also JS, CSS and Twig files to make sure we can modify the code of header-stamp without worrying of introducing a regression.

Here it is.

I will then miss the "vue" and "json" usecases 🤔 do you know modules we could use as samples ?