### PR TITLE
replace self::<constant> by static::<constant>

### DIFF
--- a/src/Command/UpdateLicensesCommand.php
+++ b/src/Command/UpdateLicensesCommand.php
@@ -118,7 +118,7 @@ class UpdateLicensesCommand extends Command
                 null,
                 InputOption::VALUE_REQUIRED,
                 'License file to apply',
-                realpath(self::DEFAULT_LICENSE_FILE)
+                realpath(static::DEFAULT_LICENSE_FILE)
             )
             ->addOption(
                 'target',
@@ -131,14 +131,14 @@ class UpdateLicensesCommand extends Command
                 null,
                 InputOption::VALUE_REQUIRED,
                 'Comma-separated list of folders and files to exclude from the update',
-                implode(',', self::DEFAULT_FILTERS)
+                implode(',', static::DEFAULT_FILTERS)
             )
             ->addOption(
                 'extensions',
                 null,
                 InputOption::VALUE_REQUIRED,
                 'Comma-separated list of file extensions to update',
-                implode(',', self::DEFAULT_EXTENSIONS)
+                implode(',', static::DEFAULT_EXTENSIONS)
             )
             ->addOption(
                 'display-report',


### PR DESCRIPTION
So that a command can extend UpdateLicensesCommand and define new values for this constants.

using static:: instead of self:: give the ability for an command extending UpdateLicencesCommand to replace constants values.
Example :  
```php
class FixLicenses extends UpdateLicensesCommand
{
    const DEFAULT_FILTERS = ['index.php','composer.json', 'vendor/'];
    const DEFAULT_LICENSE_FILE = __DIR__.'/../assets/Licence_header.txt';

    protected function configure()
    {
        parent::configure();
        $this->setName('fop:fix-licenses');
    }
}
```

ref : https://www.php.net/manual/en/language.oop5.late-static-bindings.php