### PR TITLE
Fix doc. Symfony Finder exclude() can't handle files (only directories).

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Header Stamp
 
 ![PHP tests](https://github.com/PrestaShopCorp/header-stamp/workflows/PHP%20tests/badge.svg)
-[![Build Status](https://travis-ci.com/PrestaShopCorp/header-stamp.svg?branch=master)](https://travis-ci.com/PrestaShopCorp/header-stamp)
 
 Update the headers of the current folder. This tools extracts the command originally available in the PrestaShop Core.
 

--- a/src/Command/UpdateLicensesCommand.php
+++ b/src/Command/UpdateLicensesCommand.php
@@ -80,7 +80,7 @@ class UpdateLicensesCommand extends Command
     private $extensions;
 
     /**
-     * List of folders and files to exclude from the search
+     * List of folders to exclude from the search
      *
      * @param array $filters
      */
@@ -130,7 +130,7 @@ class UpdateLicensesCommand extends Command
                 'exclude',
                 null,
                 InputOption::VALUE_REQUIRED,
-                'Comma-separated list of folders and files to exclude from the update',
+                'Comma-separated list of folders to exclude from the update',
                 implode(',', self::DEFAULT_FILTERS)
             )
             ->addOption(


### PR DESCRIPTION
exclude handles only directories, not files.

https://github.com/symfony/symfony/blob/f6dc8260eb91c5fa2ea921384f4a9101308cea5d/src/Symfony/Component/Finder/Finder.php#L691

https://symfony.com/doc/3.4/components/finder.html#location

Am I wrong ?