### PR TITLE
PHP files: avoid adding unnecessary newline

### DIFF
--- a/src/Command/UpdateLicensesCommand.php
+++ b/src/Command/UpdateLicensesCommand.php
@@ -318,12 +318,19 @@ class UpdateLicensesCommand extends Command
     {
         if (!$node->hasAttribute('comments')) {
             $needle = '<?php';
-            $replace = "<?php\n" . $this->text . "\n";
+            $replace = "<?php\n" . $this->text;
             $haystack = $file->getContents();
 
             $pos = strpos($haystack, $needle);
             // Important, if the <?php is in the middle of the file, continue
             if ($pos === 0) {
+                // Check if an empty newline is present right after the <?php tag
+                // Append newline to replacement if missing
+                $checkNewline = substr($haystack, strlen($needle), 2) === "\n\n";
+                if (!$checkNewline) {
+                    $replace .= "\n";
+                }
+
                 $newstring = substr_replace($haystack, $replace, $pos, strlen($needle));
 
                 if (!$this->runAsDry) {

--- a/tests/integration/expected/smart-headers/emptynewlineheader.php
+++ b/tests/integration/expected/smart-headers/emptynewlineheader.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+class EmptyNewlineHeader extends Module
+{
+    // This PHP file has no header comment but does have an empty newline right after the <?php tag
+    // Most editors/IDEs add this newline automatically
+    // It should add the license header without adding an unnecessary extra empty newline 
+    // This also keeps validator.prestashop.com happy :)
+}

--- a/tests/integration/module-samples/smart-headers/emptynewlineheader.php
+++ b/tests/integration/module-samples/smart-headers/emptynewlineheader.php
@@ -1,0 +1,9 @@
+<?php
+
+class EmptyNewlineHeader extends Module
+{
+    // This PHP file has no header comment but does have an empty newline right after the <?php tag
+    // Most editors/IDEs add this newline automatically
+    // It should add the license header without adding an unnecessary extra empty newline 
+    // This also keeps validator.prestashop.com happy :)
+}

--- a/tests/integration/runner/run.php
+++ b/tests/integration/runner/run.php
@@ -15,6 +15,7 @@ $modulesToTest = [
     'dashproducts',
     'fakemodule',
     'existing-headers-discrimination',
+    'smart-headers',
 ];
 $workspaceID = 100;
 $filesystem = new Filesystem();


### PR DESCRIPTION
Currently, if you have a PHP file with no header license/comment but have an empty newline right after the ```<?php``` tag:

```php
<?php

class MyModule extends Module
{
    //...
}
``` 

Then the end results will be:

```php
<?php
/**
 * Copyright since 2007 PrestaShop SA and Contributors
 * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
 *
 * NOTICE OF LICENSE
 *
 * This source file is subject to the Academic Free License version 3.0
 * that is bundled with this package in the file LICENSE.md.
 * It is also available through the world-wide-web at this URL:
 * https://opensource.org/licenses/AFL-3.0
 * If you did not receive a copy of the license and are unable to
 * obtain it through the world-wide-web, please send an email
 * to license@prestashop.com so we can send you a copy immediately.
 *
 * @author    PrestaShop SA and Contributors <contact@prestashop.com>
 * @copyright Since 2007 PrestaShop SA and Contributors
 * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
 */


class MyModule extends Module
{
    //...
}
``` 

This adds an unnecessary extra empty newline right after the comment, which isn't compliant with the module validator (validator.prestashop.com).

This PR attempts to fix this by checking if there's an empty newline right after the ```<?php``` tag and adding a newline if there isn't.

I named the sample module ```smart-headers``` but feel free to suggest another name.

PS: thank you for developing these wonderful tools that make our lives easier!