### PR TITLE
fix: json files to use correct author field

### DIFF
--- a/src/Command/UpdateLicensesCommand.php
+++ b/src/Command/UpdateLicensesCommand.php
@@ -399,10 +399,10 @@ class UpdateLicensesCommand extends Command
         $this->addLicenseToFile($file, '<!--', '-->');
     }
 
-    private function addLicenseToJsonFile(SplFileInfo $file): bool
+    private function addLicenseToJsonFile(SplFileInfo $file): void
     {
         if (!in_array($file->getFilename(), ['composer.json', 'package.json'])) {
-            return false;
+            return;
         }
 
         $content = json_decode($file->getContents(), true);
@@ -430,17 +430,13 @@ class UpdateLicensesCommand extends Command
         }
 
         if (!$this->runAsDry) {
-            $result = file_put_contents(
+            file_put_contents(
                 $this->targetDirectory . '/' . $file->getRelativePathname(),
                 $encodedContent
             );
-        } else {
-            $result = true;
         }
 
-        $this->reportOperationResult($encodedContent, json_encode($oldContent), $file->getFilename());
-
-        return false !== $result;
+        $this->reportOperationResult($encodedContent, $file->getContents(), $file->getFilename());
     }
 
     /**

--- a/src/Command/UpdateLicensesCommand.php
+++ b/src/Command/UpdateLicensesCommand.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\HeaderStamp\Command;
 
+use Exception;
 use PhpParser\Node\Stmt;
 use PhpParser\ParserFactory;
 use PrestaShop\HeaderStamp\LicenseHeader;
@@ -399,6 +400,9 @@ class UpdateLicensesCommand extends Command
         $this->addLicenseToFile($file, '<!--', '-->');
     }
 
+    /**
+     * @throws Exception
+     */
     private function addLicenseToJsonFile(SplFileInfo $file): void
     {
         if (!in_array($file->getFilename(), ['composer.json', 'package.json'])) {
@@ -406,7 +410,6 @@ class UpdateLicensesCommand extends Command
         }
 
         $content = json_decode($file->getContents(), true);
-        $oldContent = $content;
 
         $authorDetails = [
             'name' => 'PrestaShop SA',
@@ -423,6 +426,10 @@ class UpdateLicensesCommand extends Command
         $content['license'] = (false !== strpos($this->license, 'afl')) ? 'AFL-3.0' : 'OSL-3.0';
 
         $encodedContent = json_encode($content, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+
+        if (!$encodedContent) {
+            throw new Exception('File can not be encoded to JSON format');
+        }
 
         // add blank line in end of file if not exist
         if (substr($encodedContent, -1) !== "\n") {

--- a/tests/integration/expected/dashproducts/composer.json
+++ b/tests/integration/expected/dashproducts/composer.json
@@ -15,6 +15,5 @@
     "config": {
         "preferred-install": "dist"
     },
-    "type": "prestashop-module",
-    "author": "PrestaShop"
+    "type": "prestashop-module"
 }

--- a/tests/integration/expected/gsitemap/composer.json
+++ b/tests/integration/expected/gsitemap/composer.json
@@ -3,12 +3,6 @@
     "description": "PrestaShop module gsitemap",
     "homepage": "https://github.com/PrestaShop/gsitemap",
     "license": "AFL-3.0",
-    "authors": [
-        {
-            "name": "PrestaShop SA",
-            "email": "contact@prestashop.com"
-        }
-    ],
     "require": {
         "php": ">=5.6.0"
     },
@@ -16,5 +10,10 @@
         "preferred-install": "dist"
     },
     "type": "prestashop-module",
-    "author": "PrestaShop"
+    "authors": [
+        {
+            "name": "PrestaShop SA",
+            "email": "contact@prestashop.com"
+        }
+    ]
 }

--- a/tests/integration/module-samples/dashproducts/composer.json
+++ b/tests/integration/module-samples/dashproducts/composer.json
@@ -15,6 +15,5 @@
     "config": {
         "preferred-install": "dist"
     },
-    "type": "prestashop-module",
-    "author": "PrestaShop"
+    "type": "prestashop-module"
 }

--- a/tests/integration/module-samples/gsitemap/composer.json
+++ b/tests/integration/module-samples/gsitemap/composer.json
@@ -3,18 +3,11 @@
     "description": "PrestaShop module gsitemap",
     "homepage": "https://github.com/PrestaShop/gsitemap",
     "license": "AFL-3.0",
-    "authors": [
-        {
-            "name": "PrestaShop SA",
-            "email": "contact@prestashop.com"
-        }
-    ],
     "require": {
         "php": ">=5.6.0"
     },
     "config": {
         "preferred-install": "dist"
     },
-    "type": "prestashop-module",
-    "author": "PrestaShop"
+    "type": "prestashop-module"
 }

--- a/tests/integration/runner/FolderComparator.php
+++ b/tests/integration/runner/FolderComparator.php
@@ -32,7 +32,6 @@ class FolderComparator
         'autoload_static.php',
         'autoload_real.php',
         'ClassLoader.php',
-        'composer.json',
     ];
 
     /**


### PR DESCRIPTION
Currently the fields are not used in the correct way I update this :

- **composer.json** requires an `authors` field while **package.json** requires an `author` field.
- I also harmonized everything to provide maximum information :
```json
{
  "name": "PrestaShop SA",
  "email": "contact@prestashop.com"
}
```
- Another small fix is ​​to add an empty line at the end of the file so that it is not picked up by linters, syntax checkers or IDEs.