### PR TITLE
Make discriminator argument multiple

### DIFF
--- a/bin/header-stamp
+++ b/bin/header-stamp
@@ -40,7 +40,7 @@ foreach ($autoloadFiles as $autoloadFile) {
 use PrestaShop\HeaderStamp\Command\UpdateLicensesCommand;
 use Symfony\Component\Console\Application;
 
-$application = new Application('header-stamp', '3.0.0');
+$application = new Application('header-stamp', '3.1.0');
 $command = new UpdateLicensesCommand();
 
 $application->add($command);

--- a/tests/Integration/Command/UpdateLicencesCommandTest.php
+++ b/tests/Integration/Command/UpdateLicencesCommandTest.php
@@ -61,7 +61,7 @@ class UpdateLicencesCommandTest extends TestCase
     /**
      * @dataProvider getFoldersToTest
      */
-    public function testCommandModifications(string $folderToTest, bool $isFolderValid, array $invalidFiles = []): void
+    public function testCommandModifications(string $folderToTest, bool $isFolderValid, array $invalidFiles = [], string $discriminationParam = ''): void
     {
         // Prepare module workspace
         $moduleSource = __DIR__ . '/../../Resources/module-samples/' . $folderToTest;
@@ -83,9 +83,10 @@ class UpdateLicencesCommandTest extends TestCase
             '--not-name' => '*.min.js',
             '--exclude' => 'ignoredFolder',
         ];
-        if ('existing-headers-discrimination' === $folderToTest) {
-            $commandParameters['--header-discrimination-string'] = 'friendsofpresta';
+        if (!empty($discriminationParam)) {
+            $commandParameters['--header-discrimination-string'] = $discriminationParam;
         }
+
         $commandTester->execute($commandParameters);
 
         // Compare folders
@@ -135,9 +136,10 @@ class UpdateLicencesCommandTest extends TestCase
             '--exclude' => 'ignoredFolder',
             '--dry-run' => true,
         ];
-        if ('existing-headers-discrimination' === $folderToTest) {
-            $commandParameters['--header-discrimination-string'] = 'friendsofpresta';
+        if (!empty($discriminationParam)) {
+            $commandParameters['--header-discrimination-string'] = $discriminationParam;
         }
+
         $commandResult = $commandTester->execute($commandParameters);
         $this->assertEquals($isFolderValid ? 0 : 1, $commandResult);
 
@@ -195,16 +197,24 @@ class UpdateLicencesCommandTest extends TestCase
                 'FakeClassWithWrongHeader.php',
                 'composer.json',
             ],
+            // Use two discriminators (to check the implode works as expected)
+            'PrestaShop SA and Contributors,NOTICE OF LICENSE',
         ];
 
         yield 'valid module gsitemap' => [
             'gsitemap',
             true,
+            [],
+            // Use only one discriminator
+            'NOTICE OF LICENSE',
         ];
 
         yield 'valid module dashproducts' => [
             'dashproducts',
             true,
+            [],
+            // Use only one discriminator, but the other one (both are supposed to work with our test resources anyway)
+            'PrestaShop SA and Contributors',
         ];
 
         yield 'existing-headers-discrimination' => [
@@ -213,6 +223,7 @@ class UpdateLicencesCommandTest extends TestCase
             [
                 'existing-headers-discrimination.php',
             ],
+            'friendsofpresta',
         ];
 
         yield 'smart-headers' => [


### PR DESCRIPTION
We need multiple possibilities to check if a comment is a license comment

### Use case

On the core we changed the default comment from a long one to a short one https://github.com/PrestaShop/PrestaShop/pull/40768

The problem is that old files from previous PRs have the old header, which is incompatible with the new one and detected as an error. But the fixer part doesn't recognize the old header as a license header and prefixes the new one above it.

That's why we need multiple ways to identify the license comment, so we can use the header-stamp to migrate them by specifyng and old and a new discriminator.